### PR TITLE
Modified egress rule

### DIFF
--- a/rds-mssql.cfndsl.rb
+++ b/rds-mssql.cfndsl.rb
@@ -34,9 +34,7 @@ CloudFormation do
         {
           CidrIp: "0.0.0.0/0",
           Description: "outbound all for ports",
-          FromPort: -1,
-          IpProtocol: 'TCP',
-          ToPort: -1
+          IpProtocol: -1,
         }
       ]) 
       Tags tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), component_name, 'security-group' ])}]


### PR DESCRIPTION
Previous egress rule was giving a `TCP/UDP (from) port (-1) out of range` stack error.